### PR TITLE
Resolve sorting bug

### DIFF
--- a/src/vector_index.rs
+++ b/src/vector_index.rs
@@ -133,7 +133,7 @@ impl GuardedIndex {
             .map_err(|_| String::from("search_knn: Failed to acquire lock"))
             .and_then(|idx| {
                 sent_transform::search_knn(query, &idx.embeddings, results).map(|raw_results| {
-                    let x = raw_results
+                    let mut results: Vec<SearchResult> = raw_results
                         .iter()
                         .map(|raw_result| {
                             let text_body = &idx.texts[raw_result.index];
@@ -146,9 +146,9 @@ impl GuardedIndex {
                         })
                         .collect();
 
-                    x.sort();
+                    results.sort_by(|x, y| y.cmp(&x)); // Sort Vector in descending order
 
-                    x
+                    results
                 })
             })
     }


### PR DESCRIPTION
This fixes a bug where the returned `SearchResults` were correct, but unsorted. To do this, I had to implement `PartialEq`, `Eq`, `PartialOrd` and `Ord` on the `SearchResult` and call `sort_by` with a reverse order on the results Vec 